### PR TITLE
surround command arguments with quotes to handle paths containing spaces

### DIFF
--- a/lib/saxon.js
+++ b/lib/saxon.js
@@ -13,6 +13,11 @@ function parseOpts(obj){
   return ret
 };
 
+function assembleSaxonCommand(saxonJarPath, xmlPath, xslPath, opts) {
+  var options = parseOpts(opts).join(' ');
+  return util.format('java -jar "%s" "-s:%s" "-xsl:%s" %s', saxonJarPath, xmlPath, xslPath, options);
+}
+
 util.inherits(Saxon,Transform);
 
 function Saxon(jar_path,opts){
@@ -53,12 +58,8 @@ Saxon.prototype._flush = function(done){
 
   self.xml = new tmp.File();
   self.xml.writeFileSync(self.cont);
-  
-  var _opts = Array.prototype.concat.call(
-    ['-jar',self.jar_path,'-s:'+self.xml.path,'-xsl:'+self.xsl],
-    parseOpts(self.opts)
-  );
-  var cmd = require('child_process').exec('java '+_opts.join(' '),{timeout:self._timeout, maxBuffer: 1024 * 2000},function(err,stdout,stderr){
+  var command = assembleSaxonCommand(self.jar_path, self.xml.path, self.xsl, self.opts);
+  var process = require('child_process').exec(command,{timeout:self._timeout, maxBuffer: 1024 * 2000},function(err,stdout,stderr){
     if(err){
       return self.emit('error',err);
     }
@@ -70,7 +71,7 @@ Saxon.prototype._flush = function(done){
     done();
   });
 
-  cmd.on('exit',function(code,sig){
+  process.on('exit',function(code,sig){
     self.xml.unlink();
   });
 };


### PR DESCRIPTION
- fixes #2
